### PR TITLE
Update CreatedGuild.kt

### DIFF
--- a/diskord-core/src/commonMain/kotlin/com/jessecorbett/diskord/api/gateway/events/CreatedGuild.kt
+++ b/diskord-core/src/commonMain/kotlin/com/jessecorbett/diskord/api/gateway/events/CreatedGuild.kt
@@ -102,7 +102,7 @@ public data class CreatedGuildTextChannel(
     @SerialName("nsfw") override val nsfw: Boolean? = null,
     @SerialName("last_message_id") override val lastMessageId: String?,
     @SerialName("rate_limit_per_user") override val rateLimitPerUser: Int? = null,
-    @SerialName("parent_id") override val parentId: String?,
+    @SerialName("parent_id") override val parentId: String? = null,
     @SerialName("last_pin_timestamp") override val lastPinTime: String? = null
 ) : CreatedChannel(), CreatedGuildText
 


### PR DESCRIPTION
added null value for parent_id on serial_name "0". Guild Text Channel object doesn't seem to always send this.

Found an issue with the onCreateGuild event, looks like they updated the text channel object to not require "parent_id" and it's missing the null value on the constructor. 

https://github.com/JesseCorbett/Diskord/blob/4e2d68216f977a9c27758996cd7ddfb0f21f7e4d/diskord-core/src/commonMain/kotlin/com/jessecorbett/diskord/api/gateway/events/CreatedGuild.kt#L105